### PR TITLE
Extend concerns to scopes and namespaces.

### DIFF
--- a/lib/action_dispatch/routing/concerns.rb
+++ b/lib/action_dispatch/routing/concerns.rb
@@ -53,5 +53,27 @@ module ActionDispatch::Routing::Mapper::ResourcesWithConcerns
   end
 end
 
+module ActionDispatch::Routing::Mapper::ScopesWithConcerns
+  extend ActiveSupport::Concern
+
+  included do
+    alias_method_chain :scope, :concerns
+  end
+
+  def scope_with_concerns(*scopes, &block)
+    if (options_with_concerns = scopes.last).is_a?(Hash)
+      named_concerns = options_with_concerns.delete(:concerns)
+
+      scope_without_concerns(*scopes) do
+        concerns(named_concerns)
+        block.call if block_given?
+      end
+    else
+      scope_without_concerns(*scopes, &block)
+    end
+  end
+end
+
 ActionDispatch::Routing::Mapper.send :include, ActionDispatch::Routing::Mapper::Concerns
 ActionDispatch::Routing::Mapper.send :include, ActionDispatch::Routing::Mapper::ResourcesWithConcerns
+ActionDispatch::Routing::Mapper.send :include, ActionDispatch::Routing::Mapper::ScopesWithConcerns

--- a/test/routing_concerns_test.rb
+++ b/test/routing_concerns_test.rb
@@ -15,6 +15,11 @@ class CommentsController < ActionController::Base
   end
 end
 
+module Namespaced
+  class CommentsController < CommentsController
+  end
+end
+
 class RoutingConcernsTest < ActionDispatch::IntegrationTest
   Routes = ActionDispatch::Routing::RouteSet.new.tap do |app|
     app.draw do
@@ -25,6 +30,10 @@ class RoutingConcernsTest < ActionDispatch::IntegrationTest
       resources :posts, concerns: :commentable
       resource  :post,  concerns: :commentable
       resources :comments
+
+      scope 'scoped', concerns: :commentable do end
+
+      namespace 'namespaced', concerns: :commentable do end
     end
   end
 
@@ -38,6 +47,16 @@ class RoutingConcernsTest < ActionDispatch::IntegrationTest
 
   test "accessing concern from resource" do
     get "/post/comments"
+    assert_equal "200", @response.code
+  end
+
+  test "accessing concern from scope" do
+    get "/scoped/comments"
+    assert_equal "200", @response.code
+  end
+
+  test "accessing concern from namespace" do
+    get "/namespaced/comments"
     assert_equal "200", @response.code
   end
 end


### PR DESCRIPTION
As for now routing concerns were only available for resources.
Some people may need it for scopes or namespace to DRY their routes.

Fix https://github.com/rails/routing_concerns/issues/4
I'll do the same directly in Rails4 since this gem is just supposed to be backward compatibility.
